### PR TITLE
Shorten action's description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: GitHub App access token generator
-description: Generates a app installation access token to be used for cloning dependencies from other internal or private repositories using docker and golang
+description: Generates a app installation access token to be used for cloning dependencies from other internal or private repositories
 inputs:
   app-private-key:
     description: Private key for the GitHub App


### PR DESCRIPTION
## WHY

Because it should be less than `125` words.

I made it `121` 👍 