### PR TITLE
README.md: mention that private key should be Base64 encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
 |-----------------------|-------------------------------------------------|-----------|----------|
 | `app-id`              | GitHub App ID                                   | ✅         | `number` |
 | `app-installation-id` | ID of the app installation to your organization | ✅         | `number` |
-| `app-private-key`     | Private key of your GitHub App                  | ✅         | `string` |
+| `app-private-key`     | Private key of your GitHub App (Base64 encoded) | ✅         | `string` |
 
 ## Outputs
 


### PR DESCRIPTION
## WHAT


In README.md, mention that the GitHub App private key PEM must be Base64 encoded.

## WHY

Currently the only way to know this is by trial and error, or be reading the code.
It is more user friendly if the fact was mention in the README.